### PR TITLE
Update base.css

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -305,6 +305,12 @@ ol {
 	margin: 6px;
 }
 
+/* Hide extra span with bannername if no bannerimage */
+
+.SideBanner span.Banner {
+	display: none;
+}
+
 /* Tables
 -------------------------------------------------------------- */
 


### PR DESCRIPTION
Hide extra span with bannername if no bannerimage. Extra span is caused if {BannerImage} dont return image.
