### PR TITLE
Remove sort:'manual' from {CampaignProducts}

### DIFF
--- a/campaign-list.html
+++ b/campaign-list.html
@@ -21,7 +21,7 @@
 				pagination: 'true',
 				classes: 'first||',
 				limit: '30|15|60|90',
-				sort: 'manual|name_asc|released_asc|price_asc',
+				sort: 'name_asc|released_asc|price_asc',
 				before: '
 					<form action="{CurrentUrl}" method="get" id="PaginationSortForm">
 						{PaginationStatus}


### PR DESCRIPTION
CampaignProducts dont have sort: manual attribute.
