### PR TITLE
Support thousand separator on variationsplitter

### DIFF
--- a/js/mcf.variationsplitter.js
+++ b/js/mcf.variationsplitter.js
@@ -62,7 +62,7 @@ $(function() {
 					triggers: level ? _.pluck(temp, 'value') : null
 				};
 
-				var price = keyValue[1].match(/(\d+\s?\d+,\d+)/),
+				var price = keyValue[1].match(/\d?\s?\d+,\d+/),
 					availability = (availability)
 						? availability[1]
 						: $el.next('.FormHelp').text(),

--- a/js/mcf.variationsplitter.js
+++ b/js/mcf.variationsplitter.js
@@ -62,7 +62,7 @@ $(function() {
 					triggers: level ? _.pluck(temp, 'value') : null
 				};
 
-				var price = keyValue[1].match(/(\d+,\d+)/),
+				var price = keyValue[1].match(/(\d+\s?\d+,\d+)/),
 					availability = (availability)
 						? availability[1]
 						: $el.next('.FormHelp').text(),


### PR DESCRIPTION
Old regular expression on mcf.variationsplitter.js matched only prices without thousand separator.