### PR TITLE
Fix printables.css DL overflows

### DIFF
--- a/css/printables.css
+++ b/css/printables.css
@@ -289,3 +289,30 @@ tr#FullTotal td.CartTotal { font-size: 12pt; }
 	font-weight: normal;
 	margin-bottom: 4em;
 }
+
+/* Fix dl list overflow */
+
+.CartProduct dl,
+#OrderInfo dl {
+	display: flex;
+	flex-flow: row wrap;
+	padding: 0;
+}
+.CartProduct dt,
+#OrderInfo dt {
+	flex-basis: 30%;
+	margin: 0 0 5pt;
+	min-width: 33mm;
+	width: auto !important;
+	word-wrap: normal;
+	word-break: normal;
+}
+#OrderInfo dt {
+	margin-bottom: 0;
+}
+.CartProduct dd,
+#OrderInfo dd {
+	flex-basis: 50%;
+	flex-grow: 1;
+	margin: 0;
+}

--- a/invoice.html
+++ b/invoice.html
@@ -4,7 +4,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>{%Invoice} {OrderNumber}</title>
 
-<link rel="stylesheet" type="text/css" href="{ThemeUrl}/css/printables.css?date=20170803" />
+<link rel="stylesheet" type="text/css" href="{ThemeUrl}/css/printables.css?date=20200612" />
 
 </head>
 

--- a/receipt.html
+++ b/receipt.html
@@ -4,7 +4,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>{%Receipt} {OrderNumber}</title>
 
-<link rel="stylesheet" type="text/css" href="{ThemeUrl}/css/printables.css?date=20170803" />
+<link rel="stylesheet" type="text/css" href="{ThemeUrl}/css/printables.css?date=20200612" />
 
 </head>
 

--- a/returndocument.html
+++ b/returndocument.html
@@ -4,7 +4,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>{%Receipt} {OrderNumber}</title>
 
-<link rel="stylesheet" type="text/css" href="{ThemeUrl}/css/printables.css?date=20170803" />
+<link rel="stylesheet" type="text/css" href="{ThemeUrl}/css/printables.css?date=20200612" />
 
 </head>
 
@@ -46,7 +46,9 @@
 		</div>
 		<div class="AddressColumn">
 			<h3>{%OrderInformation}</h3>
-			{OrderInfo}
+			<div id="OrderInfo">
+				{OrderInfo}
+			</div>
 			<h3>{%Returner}</h3>
 			<p>
 				{OrderCustomerInformation}


### PR DESCRIPTION
Fixes ugly DL overflows in printables.

### Before fix

![image](https://user-images.githubusercontent.com/1039391/84486983-cd788e00-aca6-11ea-8f40-e21481c7092e.png)

### After fix

![image](https://user-images.githubusercontent.com/1039391/84486816-93a78780-aca6-11ea-9325-af1d69f2a5de.png)
