### PR TITLE
Add order cancellation request email template

### DIFF
--- a/emails/helpers/cancellation-request-contents.html
+++ b/emails/helpers/cancellation-request-contents.html
@@ -1,0 +1,32 @@
+<h3>{%EmailLabelOrderCancellationRequestContents}</h3>
+
+{OrderProducts(
+	before: '
+		<table style="text-align: left;" cellpadding="0" cellspacing="0" id="EmailProducts" width="100%">
+			<thead>
+				<tr valign="top">
+					<th scope="col" style="border-bottom: 2px solid #444444; padding: 12px 9px 4px 0; font-size: 15px; text-align: left;">{%Product}</th>
+					<th scope="col" style="border-bottom: 2px solid #444444; padding: 12px 0 4px 0; font-size: 15px; text-align: right;">{%Quantity}</th>
+				</tr>
+			</thead>
+	',
+	helper: {{
+		<tr valign="top">
+			<td style="border-bottom: 1px solid #D9D9D9; padding: 8px 9px 9px 0; font-size: 11px; text-align: left;">
+				<h3 style="font-size: 15px; margin: 0; padding: 0;">
+					{OrderProductName}
+					{OrderProductVariation(before:' <em style="font-weight: normal;">',after:'</em>')}
+				</h3>
+				{OrderProductCode(
+					before: '<dl><dt>{%ProductCode}</dt><dd>',
+					after: '</dd></dl>'
+				)}
+				{OrderProductChoices}
+			</td>
+			<td style="border-bottom: 1px solid #D9D9D9; padding: 8px 0 9px 0; font-size: 12px; text-align: right;">{OrderProductQuantity}</td>
+		</tr>
+	}},
+	after: '
+		</table>
+	'
+)}

--- a/emails/order/cancellation-request.html
+++ b/emails/order/cancellation-request.html
@@ -1,0 +1,36 @@
+{Helper(file:'emails/helpers/emailheader')}
+{Helper(file:'emails/helpers/simpletop')}
+
+<!-- Content table starts -->
+<table cellpadding="18" cellspacing="0" border="0" style="background: #ffffff url({ShopUrl}{ThemeUrl}/i/email-content-top.gif) repeat-x left top;" width="100%">
+	<tr>
+		<td class="ContentCell" style="font-size: 16px; line-height: 24px;" height="100%">
+
+			{%EmailTextOrderCancellationRequest}
+
+			<table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 18px 0; font-size: 14px; line-height: 21px;">
+				<tr valign="top">
+					<th scope="row" style="padding: 4px 18px 4px 0; text-align: left; white-space: nowrap;">{%EmailLabelOrderCancellationRequestReceivedAt}</th>
+					<td style="padding: 4px 0; text-align: left; width: 100%;">{OrderCancellationRequestReceivedAt}</td>
+				</tr>
+				<tr valign="top">
+					<th scope="row" style="padding: 4px 18px 4px 0; text-align: left; white-space: nowrap;">{%EmailLabelOrderCancellationRequestSubmittedBy}</th>
+					<td style="padding: 4px 0; text-align: left; width: 100%;">{OrderName}</td>
+				</tr>
+				{OrderCancellationRequestReason(
+					before: '<tr valign="top"><th scope="row" style="padding: 4px 18px 4px 0; text-align: left; white-space: nowrap;">{%EmailLabelOrderCancellationRequestReason}</th><td style="padding: 4px 0; text-align: left; width: 100%;">',
+					after: '</td></tr>'
+				)}
+			</table>
+
+			{Helper(file:'emails/helpers/cancellation-request-contents')}
+
+			<p style="font-size: 14px; line-height: 21px; color: #555;">{%OrderCancellationProcessText}</p>
+
+		</td>
+	</tr>
+</table>
+<!-- Content table ends -->
+
+{Helper(file:'emails/helpers/simplebottom')}
+{Helper(file:'emails/helpers/emailfooter')}

--- a/emails/order/cancellation-request.html
+++ b/emails/order/cancellation-request.html
@@ -27,6 +27,8 @@
 
 			<p style="font-size: 14px; line-height: 21px; color: #555;">{%OrderCancellationProcessText}</p>
 
+			<p style="font-size: 13px; line-height: 20px; color: #888;">{%EmailFooterOrderCancellationRequest}</p>
+
 		</td>
 	</tr>
 </table>


### PR DESCRIPTION
Order cancellation request confirmation email template and its product-list helper partial (2012 email theme), shown when a customer's cancellation request is received — order contents, receipt time, submitter, free-text reason, and an editable cancellation-process section.

The 2018-theme counterpart is in MyCashflow/Default-Email-Templates.